### PR TITLE
fix: adiciona atividade 'GitHub Skills' para inscrição dos estudantes

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Aprenda habilidades práticas de programação e colaboração com o GitHub. Parceria oficial anunciada pela direção. Certificação disponível.",
+        "schedule": "Sextas-feiras, 16:00 - 17:30",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
Adiciona a atividade 'GitHub Skills' ao sistema, permitindo que estudantes possam se inscrever conforme anunciado pela direção. Corrige a ausência da atividade reportada na issue #6.